### PR TITLE
Add calibration workflow

### DIFF
--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -19,7 +19,7 @@ jobs:
             --branch refactor-processing \
             --single-branch
         cd sdc_aws_processing_lambda/lambda_function
-        BRANCH_URL="https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git@${{ github.event.pull_request.head.ref }}"
+        BRANCH_URL="git+https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git@${{ github.event.pull_request.head.ref }}"
         echo "Branch URL: $BRANCH_URL"
         sed -i "s|hermes_eea @ git+https://github.com/HERMES-SOC/hermes_eea.git|hermes_eea @ $BRANCH_URL|" requirements.txt
         docker build -t processing_function:latest .

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -17,7 +17,7 @@ jobs:
         cd ..
         git clone https://github.com/dbarrous/sdc_aws_processing_lambda.git\
             --branch refactor-processing \
-            --single-branch \
+            --single-branch
         cd lambda_function
         BRANCH_URL="${{ github.event.pull_request.head.ref }}"
         echo "Branch URL: $BRANCH_URL"

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -18,7 +18,7 @@ jobs:
         git clone https://github.com/dbarrous/sdc_aws_processing_lambda.git\
             --branch refactor-processing \
             --single-branch
-        cd lambda_function
+        cd sdc_aws_processing_lambda/lambda_function
         BRANCH_URL="${{ github.event.pull_request.head.ref }}"
         echo "Branch URL: $BRANCH_URL"
         sed -i "s|hermes_eea @ git+https://github.com/HERMES-SOC/hermes_eea.git|hermes_eea @ $BRANCH_URL|" requirements.txt

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -1,6 +1,6 @@
 name: Test Lambda Function Locally and Upload Artifacts
 
-on: [pull_request, pull_request_target]
+on: [pull_request_target]
 
 jobs:
   test-and-upload:
@@ -59,7 +59,6 @@ jobs:
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v2
       # Only comment if triggered by a pull request target event
-      if: github.event_name == 'pull_request_target'
       with:
         message: |
             The processed files are available as an artifact: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -19,7 +19,7 @@ jobs:
             --branch refactor-processing \
             --single-branch
         cd sdc_aws_processing_lambda/lambda_function
-        BRANCH_URL="${{ github.event.pull_request.head.repo.full_name }}"
+        BRANCH_URL="https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git@${{ github.event.pull_request.head.ref }}"
         echo "Branch URL: $BRANCH_URL"
         sed -i "s|hermes_eea @ git+https://github.com/HERMES-SOC/hermes_eea.git|hermes_eea @ $BRANCH_URL|" requirements.txt
         docker build -t processing_function:latest .

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -35,6 +35,7 @@ jobs:
 
     - name: Test Lambda Function with curl
       run: |
+        cd ../sdc_aws_processing_lambda
         curl -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" -d @lambda_function/tests/test_data/test_eea_event.json
 
     - name: Copy Processed Files from Container

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -1,0 +1,60 @@
+name: Test Lambda Function Locally and Upload Artifacts
+
+on: [pull_request]
+
+jobs:
+  test-and-upload:
+    permissions:
+        pull-requests: write
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v3
+
+    - name: Build Lambda Docker Image
+      run: |
+        cd ..
+        git clone https://github.com/dbarrous/sdc_aws_processing_lambda.git@refactor-processing
+        cd lambda_function
+        BRANCH_URL="${{ github.event.pull_request.head.ref }}"
+        echo "Branch URL: $BRANCH_URL"
+        sed -i "s|hermes_eea @ git+https://github.com/HERMES-SOC/hermes_eea.git|hermes_eea @ $BRANCH_URL|" requirements.txt
+        docker build -t processing_function:latest .
+        
+    - name: Run Lambda Docker Container
+      run: |
+        docker run -d -p 9000:8080 -e USE_INSTRUMENT_TEST_DATA=True processing_function:latest
+        container_id=$(docker ps -qf "ancestor=processing_function:latest")
+        echo "Container ID: $container_id"
+
+    - name: Wait for Container to Initialize
+      run: sleep 5
+
+    - name: Test Lambda Function with curl
+      run: |
+        curl -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" -d @lambda_function/tests/test_data/test_eea_event.json
+
+    - name: Copy Processed Files from Container
+      run: |
+        container_id=$(docker ps -qf "ancestor=processing_function:latest")
+        # Create a directory for processed files
+        mkdir processed_files
+        # Copy the files from the container to the host
+        docker cp $container_id:/test_data/. processed_files/
+
+    - name: Upload Processed Files as Artifact
+      id: artifact-upload-step
+      uses: actions/upload-artifact@v4
+      with:
+          name: processed-files
+          path: processed_files/
+
+    - name: Echo Artifact URL
+      run: echo "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}"
+    
+    - name: Comment PR
+      uses: thollander/actions-comment-pull-request@v2
+      with:
+        message: |
+            The processed files are available as an artifact: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -32,11 +32,27 @@ jobs:
       run: sleep 5
 
     - name: Test Lambda Function with curl
+      id: test-lambda
       run: |
         cd ../sdc_aws_processing_lambda
-        curl -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" -d @lambda_function/tests/test_data/test_eea_event.json
+        # Run curl and write the HTTP status code to a variable
+        HTTP_STATUS=$(curl -X POST "http://localhost:9000/2015-03-31/functions/function/invocations" \
+                      -d @lambda_function/tests/test_data/test_eea_event.json \
+                      -o response.json -w '%{http_code}')
+    
+        # Check if the HTTP status is 200 (OK)
+        if [ "$HTTP_STATUS" -eq 200 ]; then
+          echo "Success: HTTP status is 200"
+          echo "test_success=true" >> $GITHUB_OUTPUT
+          exit 0  # Exit with success
+        else
+          echo "Error or unexpected HTTP status: $HTTP_STATUS"
+          echo "test_success=false" >> $GITHUB_OUTPUT
+          exit 1  # Exit with failure
+        fi
 
     - name: Copy Processed Files from Container
+      if: steps.test-lambda.outputs.test_success == 'true'
       run: |
         container_id=$(docker ps -qf "ancestor=processing_function:latest")
         # Create a directory for processed files
@@ -46,15 +62,18 @@ jobs:
 
     - name: Upload Processed Files as Artifact
       id: artifact-upload-step
+      if: steps.test-lambda.outputs.test_success == 'true'
       uses: actions/upload-artifact@v4
       with:
           name: processed-files
           path: processed_files/
 
     - name: Echo Artifact URL
+      if: steps.test-lambda.outputs.test_success == 'true'
       run: echo "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}"
     
     - name: Comment PR
+      if: steps.test-lambda.outputs.test_success == 'true'
       uses: thollander/actions-comment-pull-request@v2
       # Only comment if triggered by a pull request target event
       with:

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -19,7 +19,7 @@ jobs:
             --branch refactor-processing \
             --single-branch
         cd sdc_aws_processing_lambda/lambda_function
-        BRANCH_URL="${{ github.event.pull_request.head.ref }}"
+        BRANCH_URL="${{ github.event.pull_request.head.repo.full_name }}"
         echo "Branch URL: $BRANCH_URL"
         sed -i "s|hermes_eea @ git+https://github.com/HERMES-SOC/hermes_eea.git|hermes_eea @ $BRANCH_URL|" requirements.txt
         docker build -t processing_function:latest .

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -15,7 +15,9 @@ jobs:
     - name: Build Lambda Docker Image
       run: |
         cd ..
-        git clone https://github.com/dbarrous/sdc_aws_processing_lambda.git@refactor-processing
+        git clone https://github.com/dbarrous/sdc_aws_processing_lambda.git\
+            --branch refactor-processing \
+            --single-branch \
         cd lambda_function
         BRANCH_URL="${{ github.event.pull_request.head.ref }}"
         echo "Branch URL: $BRANCH_URL"

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Build Lambda Docker Image
       run: |
         cd ..
-        git clone --branch refactor-processing https://github.com/dbarrous/sdc_aws_processing_lambda.git
+        git clone https://github.com/dbarrous/sdc_aws_processing_lambda.git
         cd sdc_aws_processing_lambda/lambda_function
         BRANCH_URL="git+https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git@${{ github.event.pull_request.head.ref }}"
         echo "Branch URL: $BRANCH_URL"

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Build Lambda Docker Image
       run: |
         cd ..
-        git clone https://github.com/dbarrous/sdc_aws_processing_lambda.git
+        git clone https://github.com/HERMES-SOC/sdc_aws_processing_lambda.git
         cd sdc_aws_processing_lambda/lambda_function
         BRANCH_URL="git+https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git@${{ github.event.pull_request.head.ref }}"
         echo "Branch URL: $BRANCH_URL"

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -15,12 +15,12 @@ jobs:
     - name: Build Lambda Docker Image
       run: |
         cd ..
-        git clone https://github.com/dbarrous/sdc_aws_processing_lambda.git
+        git clone --branch refactor-processing https://github.com/dbarrous/sdc_aws_processing_lambda.git
         cd sdc_aws_processing_lambda/lambda_function
         BRANCH_URL="git+https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git@${{ github.event.pull_request.head.ref }}"
         echo "Branch URL: $BRANCH_URL"
         sed -i "s|hermes_eea @ git+https://github.com/HERMES-SOC/hermes_eea.git|hermes_eea @ $BRANCH_URL|" requirements.txt
-        docker build -t processing_function:latest .
+        docker build -t processing_function:latest . --network host
         
     - name: Run Lambda Docker Container
       run: |
@@ -34,14 +34,17 @@ jobs:
     - name: Test Lambda Function with curl
       id: test-lambda
       run: |
-        cd ../sdc_aws_processing_lambda
+        cd ../sdc_aws_processing_lambda/
         # Run curl and write the HTTP status code to a variable
-        HTTP_STATUS=$(curl -X POST "http://localhost:9000/2015-03-31/functions/function/invocations" \
-                      -d @lambda_function/tests/test_data/test_eea_event.json \
-                      -o response.json -w '%{http_code}')
-    
-        # Check if the HTTP status is 200 (OK)
-        if [ "$HTTP_STATUS" -eq 200 ]; then
+        HTTP_STATUS=$(curl -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" -d @lambda_function/tests/test_data/test_eea_event.json)
+        echo "HTTP Status: $HTTP_STATUS"
+
+        # Grep the HTTP status code from the curl output for 200 (success)
+        STATUS_CODE=$(echo $HTTP_STATUS | grep -oP '200')
+        echo "Status Code: $STATUS_CODE"
+
+        # If the HTTP status code is 200, then the test is successful
+        if [ "$STATUS_CODE" == "200" ]; then
           echo "Success: HTTP status is 200"
           echo "test_success=true" >> $GITHUB_OUTPUT
           exit 0  # Exit with success

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -15,9 +15,7 @@ jobs:
     - name: Build Lambda Docker Image
       run: |
         cd ..
-        git clone https://github.com/dbarrous/sdc_aws_processing_lambda.git\
-            --branch refactor-processing \
-            --single-branch
+        git clone https://github.com/dbarrous/sdc_aws_processing_lambda.git
         cd sdc_aws_processing_lambda/lambda_function
         BRANCH_URL="git+https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git@${{ github.event.pull_request.head.ref }}"
         echo "Branch URL: $BRANCH_URL"

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -1,6 +1,6 @@
 name: Test Lambda Function Locally and Upload Artifacts
 
-on: [pull_request]
+on: [pull_request, pull_request_target]
 
 jobs:
   test-and-upload:
@@ -58,6 +58,8 @@ jobs:
     
     - name: Comment PR
       uses: thollander/actions-comment-pull-request@v2
+      # Only comment if triggered by a pull request target event
+      if: github.event_name == 'pull_request_target'
       with:
         message: |
             The processed files are available as an artifact: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }}


### PR DESCRIPTION
This update introduces the Calibration Workflow. This workflow integrates the instrument code, which is under test in the pull request (PR), and applies it to the test binary data. The calibrated file is then uploaded as an artifact. It generates a zipped folder containing both the original and processed files.

The data for this process is sourced from the instrument test data folder, available at [HERMES-SOC/hermes_eea repository](https://github.com/HERMES-SOC/hermes_eea/tree/main/hermes_eea/data).

This workflow depends on the merge of [this PR](https://github.com/HERMES-SOC/sdc_aws_processing_lambda/pull/20) in the HERMES-SOC/sdc_aws_processing_lambda repository.

A comment containing a link to the artifact will be created automatically. However, due to GitHub's permission restrictions and the need to trigger this on a fork, it must be executed using the pull_request_target action event. This can only be triggered after the code has been committed to the repository. For a demonstration of how it works, refer to [this test PR on my personal repository](https://github.com/dbarrous/hermes_eea/pull/4).