### PR TITLE
Updates to use Pathlib rather than str or os.path

### DIFF
--- a/hermes_eea/__init__.py
+++ b/hermes_eea/__init__.py
@@ -1,5 +1,4 @@
 # Licensed under Apache License v2 - see LICENSE.rst
-import sys
 from pathlib import Path
 
 from hermes_core import log

--- a/hermes_eea/__init__.py
+++ b/hermes_eea/__init__.py
@@ -1,6 +1,6 @@
 # Licensed under Apache License v2 - see LICENSE.rst
-import os.path
 import sys
+from pathlib import Path
 
 from hermes_core import log
 from hermes_eea.io.file_tools import read_file
@@ -20,9 +20,9 @@ INST_TARGETNAME = "EEA"
 INST_TO_SHORTNAME = {INST_NAME: INST_SHORTNAME}
 INST_TO_TARGETNAME = {INST_NAME: INST_TARGETNAME}
 
-_package_directory = os.path.dirname(os.path.abspath(__file__))
-_data_directory = os.path.abspath(os.path.join(_package_directory, "data"))
-_calibration_directory = os.path.abspath(os.path.join(_data_directory, "calibration"))
+_package_directory = Path(__file__).parent
+_data_directory = _package_directory / "data"
+_calibration_directory = _data_directory / "calibration"
 
 
 log.info(f"hermes_eea version: {__version__}")

--- a/hermes_eea/calibration/calibration.py
+++ b/hermes_eea/calibration/calibration.py
@@ -199,7 +199,7 @@ def l0_sci_data_to_cdf(
 
     Returns
     -------
-    output_filename: Path
+    output_filename: `pathlib.Path`
         Fully specificied filename of cdf file
 
     Examples
@@ -262,7 +262,7 @@ def get_calibration_file(data_filename: Path, time=None) -> Path:
     Given a time, return the appropriate calibration file.
     Parameters
     ----------
-    data_filename: str
+    data_filename: `pathlib.Path`
         Fully specificied filename of the non-calibrated file (data level < 2)
     time: ~astropy.time.Time
 

--- a/hermes_eea/calibration/calibration.py
+++ b/hermes_eea/calibration/calibration.py
@@ -60,7 +60,7 @@ def process_file(data_filename: Path) -> list:
 
     Returns
     -------
-    output_filenames: `list[pathlib.Path]`
+    output_files: `list[pathlib.Path]`
         Fully specificied filenames for the output CDF files.
         The file contains CDF formatted file with n packets iincluding time and [41,4,32] skymap.
 

--- a/hermes_eea/calibration/calibration.py
+++ b/hermes_eea/calibration/calibration.py
@@ -35,9 +35,9 @@ def process_file(data_filename: Path) -> list:
     This is the entry point for the pipeline processing.
     It runs all of the various processing steps required to create a L1A Hermes CDF File.
     calls:
-    
+
     .. code-block:: python
-    
+
         calibrate_file(...)
             parse_science_filename(...)
             parse_l0_sci_packets(...)
@@ -49,7 +49,7 @@ def process_file(data_filename: Path) -> list:
                 hermes_eea_data.save(...)
         # A Custom EEA SkymapFactory
         # HermesData
-    
+
 
     Parameters
     ----------
@@ -63,7 +63,7 @@ def process_file(data_filename: Path) -> list:
     output_filenames: `list[pathlib.Path]`
         Fully specificied filenames for the output CDF files.
         The file contains CDF formatted file with n packets iincluding time and [41,4,32] skymap.
-    
+
     """
     log.info(f"Processing file {data_filename}.")
     output_files = []

--- a/hermes_eea/io/file_tools.py
+++ b/hermes_eea/io/file_tools.py
@@ -1,6 +1,6 @@
+from pathlib import Path
 from ccsdspy import FixedLength
 import numpy as np
-import os
 
 """
 This module provides a generic file reader.
@@ -9,13 +9,13 @@ This module provides a generic file reader.
 __all__ = ["read_file", "read_ccsds"]
 
 
-def read_file(data_filename):
+def read_file(data_filename: Path):
     """
     Read a file.
 
     Parameters
     ----------
-    data_filename: str
+    data_filename: `pathlib.Path`
         A file to read.
 
     Returns
@@ -29,16 +29,16 @@ def read_file(data_filename):
         with open(data_filename) as fh:
             return fh.readlines()
     except Exception:
-        raise Exception("Could not find: " + os.path.abspath(data_filename))
+        raise Exception("Could not find: " + data_filename)
 
 
-def read_ccsds(filename: str, pkt_def: FixedLength):
+def read_ccsds(filename: Path, pkt_def: FixedLength):
     """
     Read a ccsds packet file.
 
     Parameters
     ----------
-    filename: str
+    filename: `pathlib.Path`
         A file to read.
 
     pkt_def: `ccsdspy.FixedLength`

--- a/hermes_eea/tests/go_plotly.py
+++ b/hermes_eea/tests/go_plotly.py
@@ -1,5 +1,5 @@
-import os
 import sys
+from pathlib import Path
 import numpy as np
 import math
 
@@ -40,7 +40,7 @@ def read_data(file):
         print("file len:", length)
         return cdffile
     except Exception:
-        if not os.path.exists(file):
+        if not Path(file).exists():
             print(file + " does not exist")
             return None
 

--- a/hermes_eea/tests/test_calibration.py
+++ b/hermes_eea/tests/test_calibration.py
@@ -1,5 +1,4 @@
 import pytest
-import os.path
 from pathlib import Path
 import shutil
 import tempfile
@@ -16,7 +15,7 @@ from spacepy import pycdf
 
 @pytest.fixture(scope="session")  # this is a pytest fixture
 def small_level0_file(tmp_path_factory):
-    fn = Path(os.path.join(_data_directory, "hermes_EEA_l0_2023042-000000_v0.bin"))
+    fn = Path(_data_directory) / "hermes_EEA_l0_2023042-000000_v0.bin"
     return fn
 
 
@@ -32,7 +31,7 @@ def test_read_ccsdspy(small_level0_file):
 
     """
     pkt = ccsdspy.FixedLength.from_file(
-        os.path.join(hermes_eea._data_directory, "hermes_EEA_sci_packet_def.csv")
+        Path(hermes_eea._data_directory) / "hermes_EEA_sci_packet_def.csv"
     )
     result = read_ccsds(small_level0_file, pkt)
     assert len(result["ACCUM"]) == 3051
@@ -54,10 +53,12 @@ def test_process_file(small_level0_file):
             # Process the File
             output_files = calib.process_file(temp_test_file_path)
 
-            assert os.path.getsize(output_files[0]) > 0
+            for f in output_files:
+                assert isinstance(f, Path)
+            assert output_files[0].stat().st_size > 0
 
             # Ensure the file is closed before attempting to delete it
-            with pycdf.CDF(output_files[0]) as cdf:
+            with pycdf.CDF(str(output_files[0])) as cdf:
                 assert len(cdf["Epoch"][:]) == 18
 
     # Ensure the temporary directory is cleaned up even if an exception is raised (needed for Windows)

--- a/hermes_eea/tests/test_file_tools.py
+++ b/hermes_eea/tests/test_file_tools.py
@@ -1,5 +1,8 @@
+from pathlib import Path
 from hermes_eea.io.file_tools import read_file
 
 
 def test_read_file():
-    assert read_file("./hermes_eea/data/calibration/flight_stepper.txt") is not None
+    assert (
+        read_file(Path("./hermes_eea/data/calibration/flight_stepper.txt")) is not None
+    )


### PR DESCRIPTION
This PR updates the HERMES EEA processing functionality to consistently use `pathlib.Path` objects for file paths when processing files. Previously these functions used `str` objects or `os.path`, which goes against the HERMES best-practices. This PR aligns the functionality of the package with the best practices defined for the mission code development.

This PR and https://github.com/HERMES-SOC/hermes_core/pull/117 are co-dependent so we need to decide which we want to complete first. My recommendation would be to complete the Core PR first. 

I've manually tested the `sdc_aws_processing_lambda`, combining changes from both PRs , and successfully generated a CDF file. 