### PR TITLE
Switch to PyPi for CCSDSPY and pin Numpy version to fix broken test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ classifiers = [
 ]
 dependencies = [
   'hermes_core @ git+https://github.com/HERMES-SOC/hermes_core/',
-  'ccsdspy==1.1.1'
+  'ccsdspy==1.3.1',
+  'numpy>=1.19.2,<2.0.0'
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
   'hermes_core @ git+https://github.com/HERMES-SOC/hermes_core/',
-  'ccsdspy==1.3.1',
+  'ccsdspy==1.3.0',
   'numpy>=1.19.2,<2.0.0'
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
   'hermes_core @ git+https://github.com/HERMES-SOC/hermes_core/',
-  'ccsdspy==1.3.0'
+  'ccsdspy==1.2.1'
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
   'hermes_core @ git+https://github.com/HERMES-SOC/hermes_core/',
-  'ccsdspy==1.2.1'
+  'ccsdspy==1.2.0'
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
   'hermes_core @ git+https://github.com/HERMES-SOC/hermes_core/',
-  'ccsdspy==1.2.0'
+  'ccsdspy==1.1.1'
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
   'hermes_core @ git+https://github.com/HERMES-SOC/hermes_core/',
-  'ccsdspy @ git+https://github.com/ddasilva/ccsdspy.git'
+  'ccsdspy==1.3.0'
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR switches to using PyPi for the CCSDSPY package (https://github.com/CCSDSPy/ccsdspy). It also fixes the broken tests due to the update to numpy 2.0.0. 